### PR TITLE
Fix admin GET image with secret

### DIFF
--- a/lib/web_router.ex
+++ b/lib/web_router.ex
@@ -37,7 +37,6 @@ defmodule WebRouter do
 
   get Application.get_env(:web_server, :mount_at) do
     conn
-    |> fetch_params
     |> handle_image_response(payload, filename)
   end
 
@@ -70,7 +69,7 @@ defmodule WebRouter do
 
   defp verify_payload(conn, payload) do
     if needs_to_verify_urls do
-      case conn.params do
+      case fetch_params(conn).params do
         %{"sha" => sha} -> is_genuine_job(sha, payload)
         _ -> false
       end

--- a/test/web_server_test.exs
+++ b/test/web_server_test.exs
@@ -91,4 +91,21 @@ defmodule WebServerTest do
     assert req.status == 200
     assert req.resp_body == expected_body
   end
+
+  test "admin GET image with sha" do
+    Application.put_env(:security, :verify_urls, true)
+    Application.put_env(:security, :secret, "test-key")
+    payload = "W1siZiIsImF0dGFjaG1lbnRzLzIwMTQxMDIwVDA4NTY1Ny03ODMxL1NhaW5zYnVyeSdzIFNwb29reSBTcGVha2VyIC0gaW1hZ2UgMS5qcGciXV0"
+    hashed_job = Job.hash_from_payload(payload)
+    url = @admin_valid_url <> "?sha=" <> hashed_job
+    invalid_url = @admin_valid_url <> "?sha=foo"
+
+    req = conn(:get, url)
+          |> WebServer.call(@opts)
+    assert req.status == 200
+
+    req2 = conn(:get, invalid_url)
+          |> WebServer.call(@opts)
+    assert req2.status == 404
+  end
 end


### PR DESCRIPTION
The admin route was previously not parsing params, which meant that verify always vailed if url verification was enabled. Also added a test to catch this problem.
