### PR TITLE
Add support for convert/thumb options job format

### DIFF
--- a/lib/job.ex
+++ b/lib/job.ex
@@ -31,6 +31,7 @@ defmodule Job do
   def hash_from_payload(job) do
     job
     |> Payload.decode
+    |> Steps.to_unique_string
     |> Crypt.hmac256(Config.secret)
     |> String.slice(0, 16)
   end

--- a/lib/steps/stringify.ex
+++ b/lib/steps/stringify.ex
@@ -1,0 +1,31 @@
+defprotocol Steps.Stringify do
+  def stringify(data)
+end
+
+defimpl Steps.Stringify, for: List do
+  def stringify(list), do: list |> Enum.map_join &Steps.Stringify.stringify/1
+end
+
+defimpl Steps.Stringify, for: Map do
+  def stringify(map), do: map |> Enum.sort |> Steps.Stringify.stringify
+end
+
+defimpl Steps.Stringify, for: Tuple do
+  def stringify(tuple), do: tuple |> Tuple.to_list |> Steps.Stringify.stringify
+end
+
+defimpl Steps.Stringify, for: BitString do
+  def stringify(string), do: string
+end
+
+defimpl Steps.Stringify, for: Atom do
+  def stringify(atom), do: atom |> to_string
+end
+
+defimpl Steps.Stringify, for: Integer do
+  def stringify(integer), do: integer |> to_string
+end
+
+defimpl Steps.Stringify, for: Float do
+  def stringify(float), do: float |> to_string
+end

--- a/test/steps_test.exs
+++ b/test/steps_test.exs
@@ -33,4 +33,30 @@ defmodule StepsTest do
                 format: "jpg"}
     assert(commands == Steps.deserialize(steps))
   end
+
+  test "understands convert options hash" do
+    steps = [["ff", "/app/foo.jpg"],
+             ["p", "convert", "-resize 100x100^", %{"format" => "png", "frame" => 1}]]
+    commands = %Steps{file: "/app/foo.jpg",
+                convert: "#{Config.convert_command} -'[1]' -resize 100x100^ -strip png:-",
+                format: "png", frame: 1}
+    assert(commands == Steps.deserialize(steps))
+  end
+
+  test "understands thumb options hash" do
+    steps = [["ff", "/app/foo.jpg"],
+             ["p", "thumb", "100x100^", %{"format" => "png", "frame" => 1}]]
+    commands = %Steps{file: "/app/foo.jpg",
+                convert: "#{Config.convert_command} -'[1]' -resize 100x100^ -strip png:-",
+                format: "png", frame: 1}
+    assert(commands == Steps.deserialize(steps))
+  end
+
+  test "reduces steps to unique string" do
+    steps = [["f", "attachments/20141002T152132-285/Untitled.jpg"],
+             ["p", "thumb", "892x320#", %{"frame" => 0, "format" => "jpg"}]]
+    unique_string = "fattachments/20141002T152132-285/Untitled.jpgpthumb892x320#formatjpgframe0"
+
+    assert(unique_string == Steps.to_unique_string(steps))
+  end
 end

--- a/test/web_server_test.exs
+++ b/test/web_server_test.exs
@@ -85,7 +85,7 @@ defmodule WebServerTest do
 
   test "admin GET image" do
     host = System.get_env("HTTP_ENGINE_HOST")
-    expected_body = "{\"convert\":[],\"fetch\":\"#{host}/attachments/20141020T085657-7831/Sainsbury's Spooky Speaker - image 1.jpg\",\"file\":null,\"format\":\"jpg\"}"
+    expected_body = "{\"convert\":[],\"fetch\":\"#{host}/attachments/20141020T085657-7831/Sainsbury's Spooky Speaker - image 1.jpg\",\"file\":null,\"format\":\"jpg\",\"frame\":0}"
     req = conn(:get, @admin_valid_url)
           |> WebServer.call(@opts)
     assert req.status == 200


### PR DESCRIPTION
Dragonfly supports specifying the format and frame as a hash. This change
adds support for existing urls using this syntax for both convert and
thumb.

Example job created by dragonfly 1.0.7:

``` ruby
a.attachment.thumb('100x100', format: "png", frame: 1).to_a
=> [["f", "7a7/9fb/7a79fb0c87f4db253eb46aac26553351.jpg"],
    ["p", :thumb, "100x100", {:format=>"png", :frame=>1}]]
```

I added a check if `frame` is an integer, to protect against shell injection on unsigned urls.

I'm a bloody newb when it comes to Elixir, so please tell me if something should be done differently.
