### PR TITLE
Allow signing engine urls with S3 AWS4 algorithmn

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,8 @@ config :processor,
   job_worker_timeout: 15000,
   job_worker_pool_size: 10,
   http_fetch_timeout: 10000,
-  convert_command: "convert"
+  convert_command: "convert",
+  sign_urls: false
 
 # mount_at defines the entry point for the api. It has to contain
 # a :payload and a :filename param

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -24,6 +24,29 @@ defmodule Config do
     System.get_env("HTTP_ENGINE_HOST")
   end
 
+  def aws_access_key_id do
+    System.get_env("AWS_ACCESS_KEY_ID")
+    || System.get_env("AMAZON_ACCESS_KEY_ID")
+    || System.get_env("AWS_ACCESS_KEY")
+  end
+
+  def aws_secret_access_key do
+    System.get_env("AWS_SECRET_ACCESS_KEY")
+    || System.get_env("AMAZON_SECRET_ACCESS_KEY")
+    || System.get_env("AWS_SECRET_KEY")
+  end
+
+  def aws_region do
+    System.get_env("AWS_REGION")
+    || System.get_env("AMAZON_REGION")
+    || System.get_env("AWS_DEFAULT_REGION")
+    || "us-east-1"
+  end
+
+  def sign_urls do
+    Application.get_env(:processor, :sign_urls) || false
+  end
+
   def fs_base_path do
     Application.get_env(:storage, :base_path) || System.cwd
   end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule DragonflyServer.Mixfile do
       {:httpoison, "~> 0.5"},
       {:porcelain, "~> 2.0"},
       {:memcache, github: "cloud8421/memcache-ex", branch: "hibernate"},
-      {:newrelic, github: "wooga/newrelic-erlang"}
+      {:newrelic, github: "wooga/newrelic-erlang"},
+      {:aws_auth, "~> 0.2.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"cowboy": {:hex, :cowboy, "1.0.0"},
+%{"aws_auth": {:hex, :aws_auth, "0.2.4"},
+  "cowboy": {:hex, :cowboy, "1.0.0"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "decorators": {:git, "git://github.com/chrisavl/erlang_decorators.git", "b14949efc938157604447adc29a71913298fe67f", [branch: "master"]},
   "dotenv": {:hex, :dotenv, "0.0.4"},
@@ -21,4 +22,5 @@
   "porcelain": {:hex, :porcelain, "2.0.0"},
   "ranch": {:hex, :ranch, "1.0.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.1"},
-  "statman": {:git, "git://github.com/knutin/statman.git", "e6ff10815eac1e613b619e69db06d635f1a4a488", [ref: "master"]}}
+  "statman": {:git, "git://github.com/knutin/statman.git", "e6ff10815eac1e613b619e69db06d635f1a4a488", [ref: "master"]},
+  "timex": {:hex, :timex, "0.13.5"}}

--- a/test/engines_test.exs
+++ b/test/engines_test.exs
@@ -1,0 +1,31 @@
+defmodule EginesTest do
+  use ExUnit.Case
+
+  import Mock
+
+  test "can generate unsinged urls" do
+    path = "attachments/20141020T085657-7831/Sainsbury's Spooky Speaker - image 1.jpg"
+    unsigned_url = Engines.Http.url_from_path(path)
+
+    expected = "#{System.get_env("HTTP_ENGINE_HOST")}/#{path}"
+
+    assert(expected == unsigned_url)
+  end
+
+  test "can generate AWS4 signed urls" do
+    path = "attachments/20141020T085657-7831/Sainsbury's Spooky Speaker - image 1.jpg"
+
+    # force sign_urls to enabled
+    with_mock Config, [:passthrough], [sign_urls: fn -> true end] do
+      # freeze Date.now
+      with_mock Timex.Date, [:passthrough], [now: fn -> Timex.Date.epoch end] do
+        signed_url = Engines.Http.url_from_path(path)
+
+        escaped_url = Regex.escape("#{System.get_env("HTTP_ENGINE_HOST")}/#{path}")
+        expected = ~r/\A#{escaped_url}\?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=%2F19700101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=86400&X-Amz-Signature=\H{64}&X-Amz-SignedHeaders=host\Z/
+
+        assert Regex.match?(expected, signed_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is required if the dragonfly-server needs to access private files on S3.
