### PR TITLE
Use sha256 based cache keys

### DIFF
--- a/lib/job.ex
+++ b/lib/job.ex
@@ -12,7 +12,7 @@ defmodule Job do
       {:error, error} ->
         {:error, %Result{format: des.format, error: error}}
       {:ok, {format, data}} ->
-        DragonflyServer.cache_store.set(job, format, data)
+        DragonflyServer.cache_store.set(cache_key(job), format, data)
         {:ok, %Result{format: format,
                       data: data}}
     end
@@ -25,7 +25,7 @@ defmodule Job do
   end
 
   def expire(job) do
-    DragonflyServer.cache_store.delete(job)
+    DragonflyServer.cache_store.delete(cache_key(job))
   end
 
   def hash_from_payload(job) do
@@ -33,6 +33,10 @@ defmodule Job do
     |> Payload.decode
     |> Crypt.hmac256(Config.secret)
     |> String.slice(0, 16)
+  end
+
+  def cache_key(job) do
+    Crypt.sha256(job)
   end
 
   defp execute(steps = %Steps{convert: []}) do

--- a/lib/web_router.ex
+++ b/lib/web_router.ex
@@ -1,5 +1,6 @@
 defmodule WebRouter do
   import Plug.Conn
+  import Job, only: [cache_key: 1]
   use Plug.Router
 
   @max_age 31536000 # 1 year
@@ -62,7 +63,7 @@ defmodule WebRouter do
   end
 
   defp fetch_or_compute_image(payload) do
-    case DragonflyServer.cache_store.get(payload) do
+    case DragonflyServer.cache_store.get(cache_key(payload)) do
       nil -> compute_image(payload)
       match -> {:ok, match}
     end

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -34,6 +34,12 @@ defmodule JobTest do
     end
   end
 
+  test "creates sha256 cache keys" do
+    payload = "W1siZiIsImF0dGFjaG1lbnRzLzIwMTQwMTIzVDE3NTc0NS0yODIzL1VudGl0bGVkLnBuZyJdLFsicCIsImNvbnZlcnQiLCItdGh1bWJuYWlsIDI3M3gyNzNeXiAtZ3Jhdml0eSBjZW50ZXIgLWNyb3AgMjczeDI3MyswKzAgK3JlcGFnZSAtZHJhdyAncG9seWdvbiAwLDAgMjczLDI3MyAyNzMsMCBmaWxsIG5vbmUgbWF0dGUgMTM1LDEzNSBmbG9vZGZpbGwnIiwicG5nIl1d"
+    expected = "f7c9d202f0b544a95110711c9d850d3f6fc4ab72738667a69509e66b6705b0a7"
+    assert(expected == Job.cache_key(payload))
+  end
+
   defp parse_png_header(<<
     0x89, "PNG", 0x0D, 0x0A, 0x1A, 0x0A,
     _length :: size(32),


### PR DESCRIPTION
This works around a problem where long payloads exceeded the 250 char cache key limit in memcached. The new cache keys are always 64 chars.
