### PR TITLE
Support alternate encode and convert step syntax

### DIFF
--- a/lib/steps.ex
+++ b/lib/steps.ex
@@ -40,7 +40,7 @@ defmodule Steps do
     do_deserialize([normalized | tail], acc)
   end
   defp do_deserialize([["p", "thumb", size] | tail], acc) do
-    normalized = ["p", "convert", Size.expand(size), @default_image_format]
+    normalized = ["p", "convert", Size.expand(size)]
     do_deserialize([normalized | tail], acc)
   end
   defp do_deserialize([["p", "convert", instructions, options] | tail], acc) when is_map(options) do
@@ -51,8 +51,18 @@ defmodule Steps do
     new_acc = %Steps{acc | format: format, convert: [instructions | acc.convert]}
     do_deserialize(tail, new_acc)
   end
+  defp do_deserialize([["p", "convert", instructions] | tail], acc) do
+    new_acc = %Steps{acc | convert: [instructions | acc.convert]}
+    do_deserialize(tail, new_acc)
+  end
+  defp do_deserialize([["p", "encode", format] | tail], acc) do
+    do_deserialize(tail, %Steps{acc | format: format})
+  end
   defp do_deserialize([["e", format] | tail], acc) do
     do_deserialize(tail, %Steps{acc | format: format})
+  end
+  defp do_deserialize([["p", "encode", format, format_opts] | tail], acc) do
+    do_deserialize(tail, %Steps{acc | format: format, convert: [format_opts | acc.convert]})
   end
   defp do_deserialize([["e", format, format_opts] | tail], acc) do
     do_deserialize(tail, %Steps{acc | format: format, convert: [format_opts | acc.convert]})

--- a/test/steps_test.exs
+++ b/test/steps_test.exs
@@ -34,6 +34,15 @@ defmodule StepsTest do
     assert(commands == Steps.deserialize(steps))
   end
 
+  test "support convert without format" do
+    steps = [["ff", "/app/foo.jpg"],
+             ["p", "convert", "-resize 100x100^"]]
+    commands = %Steps{file: "/app/foo.jpg",
+                convert: "#{Config.convert_command} -'[0]' -resize 100x100^ -strip jpg:-",
+                format: "jpg", frame: 0}
+    assert(commands == Steps.deserialize(steps))
+  end
+
   test "understands convert options hash" do
     steps = [["ff", "/app/foo.jpg"],
              ["p", "convert", "-resize 100x100^", %{"format" => "png", "frame" => 1}]]
@@ -49,6 +58,22 @@ defmodule StepsTest do
     commands = %Steps{file: "/app/foo.jpg",
                 convert: "#{Config.convert_command} -'[1]' -resize 100x100^ -strip png:-",
                 format: "png", frame: 1}
+    assert(commands == Steps.deserialize(steps))
+  end
+
+  test "understands long encode syntax" do
+    steps = [["ff", "/app/foo.jpg"],
+             ["p", "encode", "png"]]
+    commands = %Steps{file: "/app/foo.jpg",
+                convert: [], format: "png", frame: 0}
+    assert(commands == Steps.deserialize(steps))
+  end
+
+  test "understands long encode syntax with format options" do
+    steps = [["ff", "/app/foo.jpg"],
+             ["p", "encode", "jpg", "-quality 50"]]
+    commands = %Steps{file: "/app/foo.jpg",
+                convert: "convert -'[0]' -quality 50 -strip jpg:-", format: "jpg", frame: 0}
     assert(commands == Steps.deserialize(steps))
   end
 


### PR DESCRIPTION
- Encode as "p", "encode", "jpg", "-quality 50" (as used by dragonfly gem since at least 2013)
- Convert without format "p", "convert", "-colorspace Gray"
- Drop now redundant default format in thumb step
